### PR TITLE
[rosdep] fix rosdep install --from-paths

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -19,5 +19,5 @@
   <run_depend>gazebo_ros</run_depend>
   <run_depend>std_msgs</run_depend>
   <run_depend>rosgraph_msgs</run_depend>
-  <test_depend>hsrb_gazebo_launch</test_depend>
+  <test_depend>hsrb_wrs_gazebo_launch</test_depend>
 </package>


### PR DESCRIPTION
This change fixes the command:

`rosdep install --from-paths src --ignore-src -r -y`

I noticed this while looking into https://github.com/RoboCupAtHome/RuleBook/issues/731